### PR TITLE
Use the forked version of the the hugo-strata-theme until (if?) it gets merged into master

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,8 @@ go:
 
 themes: go
 	mkdir -p themes
-	cd themes; git clone https://github.com/digitalcraftsman/hugo-strata-theme.git || true
-	cd themes/hugo-strata-theme; git reset --hard bca3b7b12aebd206dae445f4415c88ee59f215f3
+	cd themes; git clone https://github.com/marvinpinto/hugo-strata-theme.git || true
+	cd themes/hugo-strata-theme; git checkout -f relative-url-references
 
 travis-linkchecker:
 	linkchecker http://127.0.0.1:8080

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,5 +1,0 @@
-{{ "<!-- Header -->" | safeHTML }}
-<header id="header">
-  <a href="#" class="image avatar"><img src="/images/{{ .Site.Params.sidebar.avatar }}" alt="" /></a>
-  <h1>{{ .Site.Params.sidebar.bio | markdownify }}</h1>
-</header>


### PR DESCRIPTION
Trying to access http resources on an https site leads to warnings and other weirdness that I would much rather avoid.

Currently on this commit: https://github.com/marvinpinto/hugo-strata-theme/commit/122c71bdf6b0f31a6ee2f63aeeb4da123c9f3141
